### PR TITLE
Fix: getKey failure in bash manager.sh

### DIFF
--- a/manager.sh
+++ b/manager.sh
@@ -1,5 +1,5 @@
 function getKey() {
-	hexaKey=$(grep -Eo "0[xX][0-9a-fA-F]{15}+" Longvinter/Saved/Logs/Longvinter.log)
+	hexaKey=$(grep -Eo -m 1 "0[xX][0-9a-fA-F]{15}+" Longvinter/Saved/Logs/Longvinter.log)
 	hexaKey=${hexaKey: 2}
 	echo $(( 16#$hexaKey ))
 }


### PR DESCRIPTION
When hexa key is present multiple times in log file it cause function to fail, fixed it by limiting grep to retrieve only the first match.